### PR TITLE
Fix IPv6 for Web project

### DIFF
--- a/projects/web/playbooks/ipv6.yml
+++ b/projects/web/playbooks/ipv6.yml
@@ -6,9 +6,9 @@
     path: '/etc/sysctl.d/disableipv6.conf'
     state: 'absent'
 
-- name: Enable IPv6 for the running system
+- name: Make sure IPv6 is not disabled for the running system
   become: true
   become_user: root
   shell:
-    echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6
-    echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6
+    echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6
+    echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6

--- a/projects/web/playbooks/ipv6.yml
+++ b/projects/web/playbooks/ipv6.yml
@@ -1,0 +1,14 @@
+---
+# The CentOS base role currently disables IPv6, but this is causing a
+# problem for curl and other bits of the d7 role
+- name: Delete conf to disable IPv6 on boot
+  file:
+    path: '/etc/sysctl.d/disableipv6.conf'
+    state: 'absent'
+
+- name: Enable IPv6 for the running system
+  become: true
+  become_user: root
+  shell:
+    echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6
+    echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6

--- a/projects/web/playbooks/selinux.yml
+++ b/projects/web/playbooks/selinux.yml
@@ -1,8 +1,4 @@
 ---
-- name: Copy hosts file
-  copy:
-    src: /vagrant/hosts
-    dest: /etc/hosts
 - name: Enable selinux for testing
   selinux:
     state: enforcing

--- a/projects/web/playbooks/vagrant.yml
+++ b/projects/web/playbooks/vagrant.yml
@@ -4,7 +4,12 @@
   roles:
     - OULibraries.centos7
   pre_tasks:
-    - include: pretasks.yml
+    - include: selinux.yml
+  post_tasks:
+    - include: ipv6.yml
+
+
+    
 
 - hosts: d7.vagrant.localdomain
   sudo: yes

--- a/projects/web/playbooks/vagrant.yml
+++ b/projects/web/playbooks/vagrant.yml
@@ -8,12 +8,9 @@
   post_tasks:
     - include: ipv6.yml
 
-
-    
-
 - hosts: d7.vagrant.localdomain
   sudo: yes
-    
+
   pre_tasks:
     - name: /srv is a directory
       file: path=/srv state=directory mode=0755 force=yes


### PR DESCRIPTION
Dis-disable IPv6 in web project

Motivation and Context
----------------------
DNS resolution for curl (etc?) not currently working with IPv6 disabled (as configured in our current CentOS 7 base role)

How Has This Been Tested?
-------------------------
testing in progress