### PR TITLE
Install ansible 2.1.1 with pip

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -20,6 +20,8 @@ yum install -y git
 yum install -y python-pip
 pip install 'ansible==2.1.1'
 
+mkdir -pv /etc/ansible
+
 # create ansible vault secret if one doesn't exist.
 stat /vagrant/vault_password.txt &>/dev/null || bash -c '< /dev/urandom tr -dc "a-zA-Z0-9~!@#$%^&*_-" | head -c${1:-254};echo;' > /vagrant/vault_password.txt
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,11 +15,12 @@ do
 done
 
 
-# we need git and ansible to get started
+# Install git and ansible to get started
 yum install -y git
 yum install -y python-pip
 pip install 'ansible==2.1.1'
 
+# Create the default ansible config folder (pip install doesn't).
 mkdir -pv /etc/ansible
 
 # create ansible vault secret if one doesn't exist.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -17,6 +17,7 @@ done
 
 # we need git and ansible to get started
 yum install -y git
+yum install -y python-pip
 pip install 'ansible==2.1.1'
 
 # create ansible vault secret if one doesn't exist.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -17,7 +17,7 @@ done
 
 # we need git and ansible to get started
 yum install -y git
-yum install -y ansible
+pip install 'ansible==2.1.1'
 
 # create ansible vault secret if one doesn't exist.
 stat /vagrant/vault_password.txt &>/dev/null || bash -c '< /dev/urandom tr -dc "a-zA-Z0-9~!@#$%^&*_-" | head -c${1:-254};echo;' > /vagrant/vault_password.txt


### PR DESCRIPTION
Replace EPEL install with pip install and pin specific version. 

Motivation and Context
----------------------
EPEL updated to 2.2.2, which seemed to break a few things. Switching to pip seems like the easiest way to pin a specific version. 

How Has This Been Tested?
-------------------------
Vagrant up seems pretty work. Could use a more kicking around, but 2.2.2 breaks at least some of our code at the moment. 