### PR TITLE
Make webdev the default web environment.

### DIFF
--- a/projects/web/group_vars/vagrant/main.yml
+++ b/projects/web/group_vars/vagrant/main.yml
@@ -7,7 +7,7 @@
 # https://drupal-dev2.drupal.vm.test on the vagrant host to https://drupal-dev2.ngrok.io
 
 # Style of environment to build: vagrant, test or prod
-environment_name: "webtest"
+environment_name: "webdev"
 
 # Drupal site email
 drupal_sitemail: "lib-noreply@ou.edu"


### PR DESCRIPTION
Change default setting for environment_name to `webdev` 

Motivation and Context
----------------------
Stricter permissions of `webtest` and `webprod` aren't great for dev default settings. 

How Has This Been Tested?
-------------------------
Both settings currently in use, and nothing appears obviously broken with new default. 

