### PR TITLE
Undo removal of /etc/hosts management

### DIFF
--- a/projects/web/playbooks/pretasks.yml
+++ b/projects/web/playbooks/pretasks.yml
@@ -1,5 +1,5 @@
 ---
-# Some vms need to know about other VMs
+# Some VMs need to know about other VMs
 - name: Copy hosts file
   copy:
     src: /vagrant/hosts

--- a/projects/web/playbooks/pretasks.yml
+++ b/projects/web/playbooks/pretasks.yml
@@ -1,4 +1,10 @@
 ---
+# Some vms need to know about other VMs
+- name: Copy hosts file
+  copy:
+    src: /vagrant/hosts
+    dest: /etc/hosts
+
 # SELinux is permissive by default in the geerlingguy/centos7 basebox
 # so we provide a switch for enabling enforcement
 - name: Enable selinux for testing

--- a/projects/web/playbooks/vagrant.yml
+++ b/projects/web/playbooks/vagrant.yml
@@ -5,7 +5,8 @@
     - role: OULibraries.centos7
       tags: centos7
   pre_tasks:
-    - include: selinux.yml
+    - include: pretasks.yml
+      tags: pretasks
 
 - hosts: d7.vagrant.localdomain
   sudo: yes


### PR DESCRIPTION
/etc/hosts config needs to happen in the main vagrant playbook so it can happen for all web project vms, not just the ansible control machine. 

Motivation and Context
-----------------------
Reverting a bad change. 

How Has This Been Tested?
-------------------------
Vagrant up with correct /etc/hosts
