### PR TITLE
Cleanup libacct config, remove unused devel vars.

### DIFF
--- a/projects/web-light/README.md
+++ b/projects/web-light/README.md
@@ -11,18 +11,18 @@ Working vagrant_infrastructure install. A paid ngrok account.  Patience.
 Usage
 -----
 
-Configure the following in `web-light/group_vars/vagrant/secrets.yml` 
+Configure the following in `web-light/group_vars/vagrant/secrets.yml`:
 
 * `my_user` - your shell account, should match prod account for easiest synch config 
 * `my_name` - your name (for git config, etc)
-* `my_email` - your email 
-* `my_pubkey` - your public key for GitHub and site synching 
+* `my_email` - your email
+* `my_pubkey` - your public key for GitHub and site synching
+* `ssh_brokers` - ssh brokers that you'll need for synching sites
 * `my_ngrok_authtoken` - your ngrok token 
 * `my_httpd_dn_suffix` - your reserved ngrok suffix
 * `my_smtp_authuser` - smtp service credentials
 * `my_smtp_authpassword` - smtp service credentials
-* `ssh_brokers` - ssh brokers that you'll need for synching sites
-* `libacct_pubkey` - vagrant libacct pubkey
+
 
 With that done, `vagrant up` should give you a working d7 box with ngrok forwarding for sites, but won't set up any sites.
 

--- a/projects/web-light/group_vars/vagrant/main.yml
+++ b/projects/web-light/group_vars/vagrant/main.yml
@@ -4,14 +4,9 @@
 # 'vagrant' will result in permissive selinux
 environment_name: "vagrant"
 
-# Developer ID and Auth
-devel_user:
-  name: "{{ my_name }}"
-  account: "{{ my_user }}"
-  email: "{{ my_email }}"
-
-
 # empty defaults for nginx. 
 nginx_star_sites: []
 nginx_literal_sites: []
 nginx_stub_sites: []
+
+libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/projects/web/group_vars/vagrant/main.yml
+++ b/projects/web/group_vars/vagrant/main.yml
@@ -4,14 +4,9 @@
 # 'vagrant' will result in permissive selinux
 environment_name: "vagrant"
 
-# Developer ID and Auth
-devel_user:
-  name: "{{ my_name }}"
-  account: "{{ my_user }}"
-  email: "{{ my_email }}"
-
-
 # empty defaults for nginx. 
 nginx_star_sites: []
 nginx_literal_sites: []
 nginx_stub_sites: []
+
+libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'


### PR DESCRIPTION
* Moved libacct pubkey out of secrets file in web and web-light
* removed unused devel_user variables. 
* Updated web-light docs  

Motivation and Context
----------------------
libacct pubkey is published other places, so there's no reason to make it a manually configured setting. 

Testing
-------------------------
- [x] successful vagrant up with expected config. 
