### PR TITLE
Redo proxy and set d7_memory_limit

### DIFF
--- a/projects/web/host_vars/d7.vagrant.localdomain/main.yml
+++ b/projects/web/host_vars/d7.vagrant.localdomain/main.yml
@@ -32,3 +32,6 @@ smtp_authpassword: "{{ my_smtp_authpassword }}"
 sendmail_users:
   - apache
   - root
+
+# PHP Config
+d7_memory_limit: "256M"

--- a/projects/web/host_vars/d7.vagrant.localdomain/main.yml
+++ b/projects/web/host_vars/d7.vagrant.localdomain/main.yml
@@ -16,7 +16,7 @@ apc_username: "apcuser"
 apc_password: "apcpass123"
 
 # Passing the local domain on to apache
-httpd_dn_suffix: "{{ my_httpd_dn_suffix }}"
+httpd_dn_suffix: "d7.{{ my_httpd_dn_suffix }}"
 
 # root db password
 mariadb_root_pass: 'root'

--- a/projects/web/host_vars/nginx.vagrant.localdomain/main.yml
+++ b/projects/web/host_vars/nginx.vagrant.localdomain/main.yml
@@ -1,14 +1,21 @@
 # Front end
 # nginx_star_sites: [] # Use this if you have no star sites
 nginx_star_sites:
-  - name: d7.vagrant.localdomain
+  - name: "d7.{{ my_httpd_dn_suffix }}"
     upstreams:
     - name: d7-vagrant-localdomain
       servers:
         - d7.vagrant.localdomain:443
     robots: disallow
 
-nginx_literal_sites: []
+nginx_literal_sites:
+ - name: "apigate.{{ my_httpd_dn_suffix }}"
+   upstreams:
+     - name: apigate-vagrant-localdomain
+       servers:
+         - apigate.vagrant.localdomain:443
+   robots: disallow
+
 
 nginx_stub_sites: []
 


### PR DESCRIPTION
* Map Drupal sites to `*.d7...`
* Map apigate to `apigate...`
* Start setting new `d7_memory_limit` variable

Motivation and Context
----------------------
API gateway needs to be shareable, and we need more ram for sites. 

Testing
-------------------------
- [x] Successful `vagrant up` to expected config
