### PR TITLE
Remove "environment_name: vagrant" setting from web and islandora project playbooks

### DIFF
--- a/projects/islandora/group_vars/vagrant/main.yml
+++ b/projects/islandora/group_vars/vagrant/main.yml
@@ -1,7 +1,2 @@
 ---
-
-# Style of environment to build: vagrant, test or prod
-# 'vagrant' will result in permissive selinux
-environment_name: "vagrant"
-
 libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/projects/islandora/host_vars/islandora.vagrant.localdomain/main.yml
+++ b/projects/islandora/host_vars/islandora.vagrant.localdomain/main.yml
@@ -1,6 +1,6 @@
 ---
 # Style of environment to build: vagrant, test or prod
-environment_name: "vagrant"
+environment_name: "webdev"
 
 # APC?
 apc_enabled: "0"

--- a/projects/islandora/playbooks/pretasks.yml
+++ b/projects/islandora/playbooks/pretasks.yml
@@ -19,14 +19,8 @@
     dest: /etc/hosts
 
 # SELinux is permissive by default in the geerlingguy/centos7 basebox
-# so we provide a switch for enabling enforcement
-- name: Enable selinux for testing
+# and we want to match our normal config.
+- name: Enable SELinux
   selinux:
     state: enforcing
     policy: targeted
-  when: environment_name != "vagrant"
-- name: Disable selinux for vagrant dev
-  selinux:
-    state: permissive
-    policy: targeted
-  when: environment_name == "vagrant"

--- a/projects/islandora/playbooks/vagrant.yml
+++ b/projects/islandora/playbooks/vagrant.yml
@@ -36,17 +36,6 @@
      tags: d7-islandora
 
   tasks:
-    - name: Enable selinux for testing
-      selinux:
-        state: enforcing
-        policy: targeted
-      when: environment_name != "vagrant"
-    - name: Disable selinux for vagrant dev
-      selinux:
-        state: permissive
-        policy: targeted
-      when: environment_name == "vagrant"
-
     - name: Add apache user to vagrant group
       user:
         name: apache

--- a/projects/web/group_vars/vagrant/main.yml
+++ b/projects/web/group_vars/vagrant/main.yml
@@ -1,7 +1,2 @@
 ---
-
-# Style of environment to build: vagrant, test or prod
-# 'vagrant' will result in permissive selinux
-environment_name: "vagrant"
-
 libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/projects/web/playbooks/pretasks.yml
+++ b/projects/web/playbooks/pretasks.yml
@@ -19,14 +19,8 @@
     dest: /etc/hosts
 
 # SELinux is permissive by default in the geerlingguy/centos7 basebox
-# so we provide a switch for enabling enforcement
-- name: Enable selinux for testing
+# and we want to match our normal config.
+- name: Enable selinux 
   selinux:
     state: enforcing
     policy: targeted
-  when: environment_name != "vagrant"
-- name: Disable selinux for vagrant dev
-  selinux:
-    state: permissive
-    policy: targeted
-  when: environment_name == "vagrant"


### PR DESCRIPTION
Initially, we intended for `vagrant` to be a possible value for the `environment_name` variable, but that has drifted and that value isn't used for any of our roles. I'm removing that setting from our playbooks as well. 

This is sort of a breaking change because setting `environment_name: vagrant` currently puts SELinux in Permissive mode, but that conflicts with getting correct edit permissions on web dev boxes, which requires setting `environment_name: webdev`, and was probably a bad idea in any case.  

Motivation and Context
------------------------
Drift in `environment_name` variable semantics lead to overly-restrictive permissions in Islandora dev box. 

Testing
-------------------------
- [ ] successful islandora build
- [ ] successful web build