### PR TITLE
Switch back to geerlinguy.solr role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -48,8 +48,8 @@
   version: v2017-05-09.0
   name: OULibraries.users
 
-- src: https://github.com/OULibraries/ansible-role-solr
-  version: oulib
+- src: https://github.com/geerlingguy/ansible-role-solr
+  version: 3.6.2
   name: geerlingguy.solr
 
 - src: https://github.com/OULibraries/ansible-role-solr-onesearch


### PR DESCRIPTION
Switch back to geerlinguy.solr role that our fork was based on now that we're running on an Ansible release that meets it's requirements. 

Motivation and Context
----------------------
Get' passed hard-coded workaround and back to maintained version. 

Testing
-------------------------
Works in vagrant. 
