### PR TITLE
Capture changes necessary to deploy SAML2 IdP using CAS 5.x in the web project

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,6 +1,6 @@
 127.0.0.1	localhost.localdomain localhost
 192.168.96.2	ansible.vagrant.localdomain
-192.168.96.3	nginx.vagrant.localdomain
+192.168.96.3	nginx.vagrant.localdomain d7.nginx.vagrant.localdomain cas.nginx.vagrant.localdomain apigate.nginx.vagrant.localdomain solr.nginx.vagrant.localdomain islandora.nginx.vagrant.localdomain dev.nginx.vagrant.localdomain
 192.168.96.4	d7.vagrant.localdomain
 192.168.96.5	cas.vagrant.localdomain
 192.168.96.6	apigate.vagrant.localdomain

--- a/projects/web/host_vars/cas.vagrant.localdomain/main.yml
+++ b/projects/web/host_vars/cas.vagrant.localdomain/main.yml
@@ -13,9 +13,21 @@ cas_services:
 # Unique ID for CAS node
 cas_host_name: cas.vagrant.localdomain
 
+# Let CAS know what its external endpoint is
+cas_server_name: "https://cas.{{ my_httpd_dn_suffix }}"
+
+# Add self-signed nginx cert to keystore used by cas client code:
+cas_import_tls_cert:
+  - hostname: cas.nginx.vagrant.localdomain
+    port: 443
+
+# Configure IdP-specifics
+cas_samlIdp_hostName: "cas.{{ my_httpd_dn_suffix }}"
+cas_samlIdp_scope: "{{ my_httpd_dn_suffix }}"
+
 # Specify a cas overlay
-cas_overlay_repo: "https://github.com/OULibraries/cas-overlay.git"
-cas_overlay_version: "4.1-oulib"
+cas_overlay_repo: "https://github.com/apereo/cas-overlay-template.git"
+cas_overlay_version: "5.2"
 
 # CAS login screen verbiage variables
 cas_screen_welcome_instructions: "Login with your OUNetID (4x4)"

--- a/projects/web/host_vars/cas.vagrant.localdomain/main.yml
+++ b/projects/web/host_vars/cas.vagrant.localdomain/main.yml
@@ -9,6 +9,8 @@ cas_services:
     logoutUrl: "https://.*{{ my_httpd_dn_suffix }}/caslogout"
     logoutType: "NONE"
 
+# Turn on SAML2 IdP
+cas_saml2_idp: true
 
 # Unique ID for CAS node
 cas_host_name: cas.vagrant.localdomain

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@
   name: OULibraries.apache2
 
 - src: https://github.com/OULibraries/ansible-role-cas
-  version: master
+  version: dev-overlay-5x
   name: OULibraries.cas
 
 - src: https://github.com/OULibraries/ansible-role-celery-worker


### PR DESCRIPTION
Mostly changes dependencies, but also sets some new vars, and modifies the hosts files, so that on-guest clients can directly reach (some) things proxied by nginx via boxname.nginx.vagrant.localdomain.

Motivation and Context
----------------------
CAS has to be able to talk to itself via hairpin, so this was the shortest path to that working.
Some of these changes you won't want to keep, but you'll want to revert others pending acceptance of prs in other projects. I included pretty much everything but my own ldap config and ssh stuff to make it easier for y'all to start testing.

Testing
-------------------------
plenty o' vagrant up on the web project.
