### PR TITLE
Configure ansible in Vagrantfile, don't use symlink.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,24 +83,10 @@ Configuration
 
 1. Select your desired project and configure it to build as follows:
 
-	  On **Linux** or **MacOS**, create a `project` symlink to specify the project that you want to build.
-	  ```
-	  # Linux or MacOS
-	  ln -s projects/example project
-	  ```
-
-	  On **Windows**, you will need to edit two files: `Vagrantfile` and `ansible.cfg`
-
 	  In `Vagrantfile`, specify your project
 	  ```
-	  -vagrantfile_project="project"
+	  -vagrantfile_project="projects/generic"
 	  +vagrantfile_project="projects/web-light"
-	  ```
-
-	  In the `ansible.cfg`, specify the path to your projects inventory
-	  ```
-	  -inventory = /vagrant/project/inventory.py
-	  +inventory = /vagrant/projects/web-light/inventory.py
 	  ```
 
 1. **Review the `README` for your project and perform any required steps.** This will probably include adding credentials and personal settings to a `secrets.yml` file. If your desired project doesn't have a `README` yet, harrass it's author.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,10 +3,30 @@
 
 ##### Config
 
-vagrant_project ="project"
+# Set the project that you would like to build
+# by default, we built the trival dev project
+vagrant_project ="projects/generic"
 
 ##### End of Config
 
+
+# Configure Ansible for specified project
+ansible_cfg =<<CFG 
+[defaults]
+roles_path = /vagrant/roles 
+host_key_checking = False
+log_path = /vagrant/ansible.log
+vault_password_file = /vagrant/scripts/vaultpw.sh
+inventory = /vagrant/#{vagrant_project}/inventory.py
+forks = 100
+[ssh_connection]
+scp_if_ssh = True
+CFG
+open('ansible.cfg', 'w') do |f|
+  f.puts ansible_cfg
+end
+
+# What am I doing?
 vagrant_user = ENV.fetch("OULIB_USER", "vagrant")
 vagrant_command = ARGV[0]
 vagrantfile_path = File.dirname(__FILE__)
@@ -20,7 +40,7 @@ VAGRANTFILE_API_VERSION = "2"
 # Many Recent vagrant releases have been buggy, so we've blacklisted
 # specific releases and ones we haven't gotten around to testing yet.
 # Feel free to uncomment and try a new release if you feel lucky!
-Vagrant.require_version( "<=1.9.4")
+
 # - 1.9.4 is known to work on Linux, Windows, and MacOS
 Vagrant.require_version( "!=1.9.3") # broken SMB sync
 # - 1.9.2 might be OK.
@@ -31,35 +51,35 @@ Vagrant.require_version( "!=1.8.5") # broken ssh permissions
 # - 1.8.4 is known to be good on MacOs and Windows
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Default configuration for all VMs
-  if Vagrant.has_plugin?("vagrant-vbguest")
-    config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-    config.vbguest.auto_update = false
-  end
-  config.vm.box = "geerlingguy/centos7"
-  config.vm.box_version = "1.1.7"
-  config.ssh.forward_agent = true
-  config.vm.provider :virtualbox do |v|
-    v.cpus = 1
-    v.memory = 512
-    v.linked_clone = true
-  end
+# Default configuration for all VMs
+if Vagrant.has_plugin?("vagrant-vbguest")
+config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+config.vbguest.auto_update = false
+end
+config.vm.box = "geerlingguy/centos7"
+config.vm.box_version = "1.1.7"
+config.ssh.forward_agent = true
+config.vm.provider :virtualbox do |v|
+v.cpus = 1
+v.memory = 512
+v.linked_clone = true
+end
 
-  # Use a "real" user for interactive logins
-  if  ['ssh', 'scp'].include? vagrant_command
-    # Maybe you want to set this to a real account
-    config.ssh.username = vagrant_user
-  end
+# Use a "real" user for interactive logins
+if  ['ssh', 'scp'].include? vagrant_command
+# Maybe you want to set this to a real account
+config.ssh.username = vagrant_user
+end
 
 
-  # Load and build project VMs
-  # Use binding.eval to make sure that we're in the right scope.
-  binding.eval(File.read(File.expand_path(vagrantfile_path+'/'+ vagrant_project+"/vagrant.rb")))
+# Load and build project VMs
+# Use binding.eval to make sure that we're in the right scope.
+binding.eval(File.read(File.expand_path(vagrantfile_path+'/'+ vagrant_project+"/vagrant.rb")))
 
-  # Build Ansible control machine and run vagrant playbook
-  config.vm.define "ansible" do |ansible|
-    ansible.vm.hostname = "ansible.vagrant.localdomain"
-    ansible.vm.network "private_network", ip: "192.168.96.2", :netmask => "255.255.255.0"
+# Build Ansible control machine and run vagrant playbook
+config.vm.define "ansible" do |ansible|
+ansible.vm.hostname = "ansible.vagrant.localdomain"
+ansible.vm.network "private_network", ip: "192.168.96.2", :netmask => "255.255.255.0"
     ansible.vm.provider :virtualbox do |v|
       v.memory = 256  # Keeping overhead low
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,13 +34,9 @@ vagrantfile_path = File.dirname(__FILE__)
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-
 # VAGRANT COMPATIBILITY 
 #
-# Many Recent vagrant releases have been buggy, so we've blacklisted
-# specific releases and ones we haven't gotten around to testing yet.
-# Feel free to uncomment and try a new release if you feel lucky!
-
+# Many recent vagrant releases have been buggy.
 # - 1.9.4 is known to work on Linux, Windows, and MacOS
 Vagrant.require_version( "!=1.9.3") # broken SMB sync
 # - 1.9.2 might be OK.
@@ -53,22 +49,22 @@ Vagrant.require_version( "!=1.8.5") # broken ssh permissions
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 # Default configuration for all VMs
 if Vagrant.has_plugin?("vagrant-vbguest")
-config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-config.vbguest.auto_update = false
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  config.vbguest.auto_update = false
 end
 config.vm.box = "geerlingguy/centos7"
 config.vm.box_version = "1.1.7"
 config.ssh.forward_agent = true
 config.vm.provider :virtualbox do |v|
-v.cpus = 1
-v.memory = 512
-v.linked_clone = true
+  v.cpus = 1
+  v.memory = 512
+  v.linked_clone = true
 end
 
 # Use a "real" user for interactive logins
 if  ['ssh', 'scp'].include? vagrant_command
-# Maybe you want to set this to a real account
-config.ssh.username = vagrant_user
+  # Maybe you want to set this to a real account
+  config.ssh.username = vagrant_user
 end
 
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,9 +1,0 @@
-[defaults]
-roles_path = /vagrant/roles 
-host_key_checking = False
-log_path = /vagrant/ansible.log
-vault_password_file = /vagrant/scripts/vaultpw.sh
-inventory = /vagrant/project/inventory.py
-forks = 100
-[ssh_connection]
-scp_if_ssh = True


### PR DESCRIPTION
* Write `ansible.cfg` from Vagrantfile. 
* Standardize setup instructions across platforms. 

Motivation and Context
----------------------
Simplifies setup of project.

Testing
-------------------------
Works in multiple vagrant ups. 
