### PR TITLE
Better Ansible inventory

### DIFF
--- a/scripts/inventory.py
+++ b/scripts/inventory.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
 import json
+import os
+
+# Get current directory
+cwd = os.path.dirname(os.path.abspath(__file__))
 
 # Ansible inventory skeleton for Vagrant use
 inventory = {
@@ -9,12 +13,18 @@ inventory = {
     }
 }
 
-# Read vagrant hosts file (/etc/hosts format) 
-with open( "/vagrant/hosts", "r") as hosts:
+# Read vagrant hosts from Vagrantfile
+with open( "/vagrant/Vagrantfile", "r") as hosts:
     for line in hosts:
-        my_host = line.split()[1]
-        if( my_host == "localhost.localdomain"): continue
-        inventory['vagrant']['hosts'].append(my_host)
+        if( "vagrant.localdomain" in line):
+            my_host = line.split("=")[1].replace('"', '').strip()
+            inventory['vagrant']['hosts'].append(my_host)
+
+# Read vagrant hosts from project-specific vagrant.rb
+with open( cwd + "/vagrant.rb", "r") as hosts:
+    for line in hosts:
+        if( "vagrant.localdomain" in line):
+            my_host = line.split("=")[1].replace('"', '').strip()
+            inventory['vagrant']['hosts'].append(my_host)
 
 print json.dumps(inventory)
-


### PR DESCRIPTION
Better Ansible inventory

I updated the ansible inventory script to not include irrelevant boxes.

Motivation and Context
----------------------
Beyond the angry red text, the ansible errors pass through to the vagrant provisioning status, so vagrant up && vagrant ssh can't work. This is annoying.

Testing
-------------------------
vagrant up/provision of several projects
