### PR TITLE
Use bento box instead of geerlingguy box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 
 # Set the project that you would like to build
 # by default, we built the trival dev project
-vagrant_project ="projects/wpn"
+vagrant_project ="projects/generic"
 
 ##### End of Config
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 
 # Set the project that you would like to build
 # by default, we built the trival dev project
-vagrant_project ="projects/generic"
+vagrant_project ="projects/wpn"
 
 ##### End of Config
 
@@ -52,8 +52,7 @@ if Vagrant.has_plugin?("vagrant-vbguest")
   config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   config.vbguest.auto_update = false
 end
-config.vm.box = "geerlingguy/centos7"
-config.vm.box_version = "1.1.7"
+config.vm.box = "bento/centos-7"
 config.ssh.forward_agent = true
 config.vm.provider :virtualbox do |v|
   v.cpus = 1

--- a/projects/dspace/group_vars/vagrant/main.yml
+++ b/projects/dspace/group_vars/vagrant/main.yml
@@ -1,2 +1,5 @@
 ---
+ansible_connection: ssh
+ansible_ssh_user: vagrant
+ansible_ssh_pass: vagrant
 libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/projects/generic/group_vars/vagrant/main.yml
+++ b/projects/generic/group_vars/vagrant/main.yml
@@ -1,2 +1,5 @@
 ---
+ansible_connection: ssh
+ansible_ssh_user: vagrant
+ansible_ssh_pass: vagrant
 libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/projects/islandora/group_vars/vagrant/main.yml
+++ b/projects/islandora/group_vars/vagrant/main.yml
@@ -1,2 +1,5 @@
 ---
+ansible_connection: ssh
+ansible_ssh_user: vagrant
+ansible_ssh_pass: vagrant
 libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/projects/ojs/group_vars/vagrant/main.yml
+++ b/projects/ojs/group_vars/vagrant/main.yml
@@ -1,2 +1,5 @@
 ---
+ansible_connection: ssh
+ansible_ssh_user: vagrant
+ansible_ssh_pass: vagrant
 environment_name: "vagrant"

--- a/projects/web-light/group_vars/vagrant/main.yml
+++ b/projects/web-light/group_vars/vagrant/main.yml
@@ -1,2 +1,5 @@
 ---
+ansible_connection: ssh
+ansible_ssh_user: vagrant
+ansible_ssh_pass: vagrant
 libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/projects/web/group_vars/vagrant/main.yml
+++ b/projects/web/group_vars/vagrant/main.yml
@@ -1,2 +1,5 @@
 ---
+ansible_connection: ssh
+ansible_ssh_user: vagrant
+ansible_ssh_pass: vagrant
 libacct_pubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtkaGGkonm3HJmRoupKgM0A04uZu3aPhFyWmyMWCHTk1TtDskTgO0krOgUKuxAB2G/d39Xz6oISL9+dQdZt5aEJK7WoHpkK8l8xXfrIJ8OiWuJ+IRygjjLsib8tVTRsEIvMrQUtnhGzVNM7lQNXaEviGmR+ZunH68fv/QpomR5qW/veLFsR0KQLnd8yoG2+Tm8EdYouDcUPTS1nr9XdPSWGcsvpDq48JdxSmtXXC/8NHfdhpmCMmoC/IXbFl7typeLd9gt7EFvqOLWEbysEF3hD6hMAV3MEWaDnhf25n2cUgdAvdk086REgg2bXx1dBdeSi+wq5MadfP80UuPuaN2lw== libacct@ou.edu'

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,7 +10,7 @@ yum check-update
 
 # Install git and ansible to get started
 yum install -y epel-release
-yum install -y git gcc openssl-devel python-devel python2-pip
+yum install -y git gcc openssl-devel python-devel python2-pip sshpass
 pip install 'ansible==2.3.1.0'
 
 # Create the default ansible config folder (pip install doesn't).
@@ -23,7 +23,7 @@ stat /vagrant/vault_password.txt &>/dev/null || bash -c '< /dev/urandom tr -dc "
 # ansible complains if this file is on the windows share because permissions
 cp /vagrant/ansible.cfg /etc/ansible/ansible.cfg
 chown root:wheel /etc/ansible/ansible.cfg
-chmod 640 /etc/ansible/ansible.cfg
+chmod 644 /etc/ansible/ansible.cfg
 
 # ansible uses the inventory path to locate group and host vars so we have to
 # make sure the script is in the project folder

--- a/scripts/inventory.py
+++ b/scripts/inventory.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
 import json
+import os
+
+# Get current directory
+cwd = os.path.dirname(os.path.abspath(__file__))
 
 # Ansible inventory skeleton for Vagrant use
 inventory = {
@@ -9,12 +13,18 @@ inventory = {
     }
 }
 
-# Read vagrant hosts file (/etc/hosts format) 
-with open( "/vagrant/hosts", "r") as hosts:
+# Read vagrant hosts from Vagrantfile
+with open( "/vagrant/Vagrantfile", "r") as hosts:
     for line in hosts:
-        my_host = line.split()[1]
-        if( my_host == "localhost.localdomain"): continue
-        inventory['vagrant']['hosts'].append(my_host)
+        if( "vagrant.localdomain" in line):
+            my_host = line.split("=")[1].replace('"', '').strip()
+            inventory['vagrant']['hosts'].append(my_host)
+
+# Read vagrant hosts from project-specific vagrant.rb
+with open( cwd + "/vagrant.rb", "r") as hosts:
+    for line in hosts:
+        if( "vagrant.localdomain" in line):
+            my_host = line.split("=")[1].replace('"', '').strip()
+            inventory['vagrant']['hosts'].append(my_host)
 
 print json.dumps(inventory)
-


### PR DESCRIPTION
Use bento box instead of geerlingguy box

Swaps out the base box to the hashicorp recommendation of a centos 7 bento box.  Switches ansible over to password login so that it won't break if the vagrant ssh key gets swapped out. This also includes the updated inventory changes in https://github.com/OULibraries/vagrant_infrastructure/pull/56

Motivation and Context
----------------------
Hashicorp recommends the use of bento base boxes for anyone not using the default hashicorp provided box. the bento boxes are used in very large-scale CI deployments are quickly updated and well tested in order to meet those needs. I've found them to be a little less buggy over time compared with geerlingguy's boxes.

Testing
-------------------------
months of development in vagrant environments using bento boxes.
